### PR TITLE
+ dynamically login to a registry via docker-variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,13 @@ echo "docker pull registry.smth.com/app:latest" >> ./kind/before-cluster.sh
 ```
 
 Then the `before-cluster.sh` hook will fire during the build and have all the details it needs to login and pull the private images.
+
+or dynamically supply the credentials when running the image:
+
+```
+docker run --privileged \
+  -e REGISTRY="registry.smth.com" \
+  -e REGISTRY_USER="username" \
+  -e REGISTRY_PASSWORD='$REGISTRY_TOKEN' \
+  bsycorp/kind:latest-1.10
+```

--- a/resources/start.sh
+++ b/resources/start.sh
@@ -19,6 +19,13 @@ docker info
 echo "Docker ready"
 touch /var/kube-config/docker-ready
 
+echo "Logging into docker-registry $REGISTRY with user $REGISTRY_USER"
+if [[ -n "${REGISTRY}" ]] && [[ -n "${REGISTRY_USER}" ]] && [[ -n "${REGISTRY_PASSWORD}" ]]; then
+    docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASSWORD" $REGISTRY || echo "WARN: Login Failed!"
+else
+    echo "no docker-registry/-credentials supplied"
+fi
+
 echo "Starting config server.."
 supervisorctl -c /etc/supervisord.conf start config-serve
 


### PR DESCRIPTION
Hi,

nice work! Supplying registry-credentials at build-time might not be desirable. With this pr it's possible to do this via environment-variables.

regards,
Roman