### PR TITLE
Add socat package (requirement for port-forward)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,6 +33,9 @@ trap finish EXIT
 
 set -ex
 
+# Required for `kubectl port-forward` to work
+apk add --no-cache socat
+
 echo "Starting dind"
 CONTAINER_ID=$(docker run --privileged -d --rm docker:$DOCKER_IMAGE)
 docker cp resources/setup.sh $CONTAINER_ID:/setup.sh


### PR DESCRIPTION
Hi there!

I was playing around with this and found it really useful as a throw-away alternative for minikube (specially on Windows). Thank you for your work!

Most of Kubernetes works as one would expect but the `port-forward` subcommand.

If you think supporting it is a nice feature for kind itself here's a patch to make it work, it just `socat` that's required. Otherwise I'd keep this a local change to my `before-cluster.sh` in my fork.