### PR TITLE
Set up public nameservers instead of relying on nameserver provided by the host

### DIFF
--- a/resources/setup.sh
+++ b/resources/setup.sh
@@ -31,7 +31,7 @@ rm -f glibc.apk
 
 # fire before cluster hook
 source /before-cluster.sh
-    
+
 # get kube binaries
 curl -Lo /usr/local/bin/minikube https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube-linux-amd64 && chmod +x /usr/local/bin/minikube
 curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && chmod +x /usr/local/bin/kubectl
@@ -57,8 +57,8 @@ fi
     while [ ! -f /tmp/setup-done ]; do
         sleep 5
         echo "(Re)starting kubelet.."
-        # ensure replace host is run before kubelet is fired, can't exactly time when kubeadm creates configs 
-        replaceHost 
+        # ensure replace host is run before kubelet is fired, can't exactly time when kubeadm creates configs
+        replaceHost
         /kubelet.sh || true
     done
 } &
@@ -84,7 +84,7 @@ kubectl -n kube-system create -f kube-proxy-cm.yaml
 rm -f kube-proxy-cm.yaml
 
 # workaround for https://github.com/bsycorp/kind/issues/19
-kubectl -n kube-system get cm coredns -o yaml | sed 's|loop||g' > coredns-cm.yaml
+kubectl -n kube-system get cm coredns -o yaml | sed 's|/etc/resolv.conf|8.8.8.8 9.9.9.9|g' > coredns-cm.yaml
 kubectl -n kube-system delete cm coredns
 kubectl -n kube-system create -f coredns-cm.yaml
 rm -f coredns-cm.yaml


### PR DESCRIPTION
Turns out https://github.com/bsycorp/kind/issues/19 didn't fix the DNS issues, it just hid them.

### Symptom

The `coredns` containers don't go into `CrashLoopBackOff` immediately (as it was happening in https://github.com/bsycorp/kind/issues/19). They start normally, until they receive a DNS request. At that moment, their status change to `OOMKill`, then `CrashLoopBackOff`.

### Reason

The coredns' `loop` plugin was correct, there is a dns request loop happening to requests, specially the ones that are meant to go out to the internet. 

When running docker as noted in the README.md, the default networking setup is to copy the nameservers from the host:

```
$ docker run -it --privileged -p 8443:8443 -p 10080:10080 bsycorp/kind:latest-1.14 bash

bash-4.4# cat /etc/resolv.conf 
# This file is included on the metadata iso
nameserver 192.168.65.1
domain somedomain.com
bash-4.4# 
```

When using docker-compose, the tool creates a user-defined network with an "embedded dns" so that the containers can refer to each other by name. Now, the same happens with docker with a user-defined network, so I'll keep the examples to pure docker:

```
$ docker network create test
79af17bef0f9bcbafce008920e5bdc3b29ea10de837281b10b9344d455967ae7

$ docker run -d --name=dind-test --net=test --privileged bsycorp/kind:latest-1.14
ef81763f79c9655bbba88ad6ae4c423fa816be8e9b4834f37912d616044e3b13

docker exec dind-test cat /etc/resolv.conf
nameserver 127.0.0.11
options ndots:0
```

In this case, 127.0.0.11 is the [embedded DNS](https://docs.docker.com/v17.09/engine/userguide/networking/configure-dns/) provided by docker when the setup involves a user-defined network. More about how it actually works [here](https://stackoverflow.com/a/50730336).

### How does this affects coredns?

When starting coredns, kubelet passes the `/etc/resolv.conf` nameservers provided to the `kind` container by docker. And this `resolv.conf` file can either contain the hosts' namerservers (when running with default settings) or `127.0.0.11`when running with an user-defined network.

In the first case, both the kind container and the coredns containers send outward requests to the internet. But in the second case, `127.0.0.11` is only valid from the`kind` container, but not from the coredns container. `127.0.0.11` essentially becomes itself, so when dns requests arrive to coredns, coredns will forward it to **itself**, hence the loop.

The error logs say:

```
2019-06-18T06:17:53.244Z [FATAL] plugin/loop: Loop (127.0.0.1:43653 -> :53) detected for zone ".", see https://coredns.io/plugins/loop#troubleshooting. Query: "HINFO 258300046549584634.8110811516357764891."
```
This was confusing because it says that a request was being received from 127.0.0.1:43653 and then forwarded to **127.0.0.1:53**. The reality is that it's being forwarded to **127.0.0.11**, but that is still localhost (from the coredns container's perspective). This issue is also explaned [here](https://github.com/moby/moby/issues/20037#issuecomment-181528117).

### Proposed solution

Let's leave the `loop` plugin, but instead of letting the coredns fowarding configuration be `forward . /etc/resolv.conf` we should change it to `forward . 8.8.8.8 9.9.9.9` (Google's public DNS servers).

Please let me know if you need more context.

**More info:**

- https://github.com/moby/moby/issues/20037
- https://github.com/coredns/coredns/issues/1986#issuecomment-406327310
- https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/#known-issues