### PR TITLE
Update Docker to 19.03.5-dind 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ During the build phase `kind` adds `172.30.99.1` to the default network interfac
 
 Doing this network trickery means we can move all the hard work into the build phase, and `kind` can startup fast. In our CI environment using `kind` a single node cluster comes up and is ready to use in 30 seconds, down from 4 minutes in the simple minikube implementation (3+ minutes is a lot in a CI pipeline!).
 
-A further optimisation is to have the build phase `docker pull` any dependent images your Kubernetes resources will require, so when your CI process is deploying your Kubernetes resources it doesn't have to pull in any images over the network. To do this you will need to build your own version of `kind` and just overwrite the `/images.sh` file with the images your want to pull in.
+A further optimisation is to have the build phase `docker pull` any dependent images your Kubernetes resources will require, so when your CI process is deploying your Kubernetes resources it doesn't have to pull in any images over the network. To do this you will need to build your own version of `kind` and update the `/after-cluster.sh` file with the images you want to pull in.
 
 ## How do I use this?
 
@@ -78,9 +78,9 @@ Pre-built images are available on dockerhub (https://hub.docker.com/r/bsycorp/ki
 
 Run `./build.sh <image name>` to build the image. Add your custom images to `/images.sh` to have them be available at runtime. These environment variables are available to configure the build:
 
-- DOCKER_IMAGE: defaults to `stable-dind`
-- MINIKUBE_VERSION: defaults to `v0.28.0`
-- KUBERNETES_VERSION: defaults to `v1.10.5`
+- DOCKER_IMAGE: defaults to `19.03.5-dind`
+- MINIKUBE_VERSION: defaults to `v1.0.1`
+- KUBERNETES_VERSION: defaults to `v1.14.8`
 - STATIC_IP: defaults to `172.30.99.1`
 
 We use git submodules to pull in this project and then add images and CI configuration around it, but there are other ways to do it.

--- a/build.sh
+++ b/build.sh
@@ -50,7 +50,6 @@ docker cp before-cluster.sh $CONTAINER_ID:/before-cluster.sh
 docker cp after-cluster.sh $CONTAINER_ID:/after-cluster.sh
 
 echo "Starting setup"
-sleep 3
 docker exec $CONTAINER_ID /setup.sh $KUBERNETES_VERSION $MINIKUBE_VERSION $STATIC_IP
 echo "Commiting new container"
 docker commit \

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ if [ -z "$DOCKER_IMAGE" ]; then
 fi
 
 if [ -z "$MINIKUBE_VERSION" ]; then
-	MINIKUBE_VERSION="v1.0.1"
+	MINIKUBE_VERSION="v1.3.0"
 	echo "Defaulting Minikube version to $MINIKUBE_VERSION"
 fi
 
@@ -39,7 +39,7 @@ trap finish EXIT
 set -e
 
 echo "Starting dind"
-CONTAINER_ID=$(docker run -e DOCKER_TLS_CERTDIR=/certs --network $NETWORK --privileged -d --rm docker:$DOCKER_IMAGE)
+CONTAINER_ID=$(docker run --network $NETWORK --privileged -d --rm docker:$DOCKER_IMAGE dockerd)
 echo $CONTAINER_ID
 docker cp resources/entrypoint.sh $CONTAINER_ID:/entrypoint.sh
 docker cp resources/setup.sh $CONTAINER_ID:/setup.sh

--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,6 @@ set -e
 
 echo "Starting dind"
 CONTAINER_ID=$(docker run --network $NETWORK --privileged -d --rm -e DOCKER_TLS_CERTDIR='' docker:$DOCKER_IMAGE dockerd)
-echo $CONTAINER_ID
 docker cp resources/entrypoint.sh $CONTAINER_ID:/entrypoint.sh
 docker cp resources/setup.sh $CONTAINER_ID:/setup.sh
 docker cp resources/start.sh $CONTAINER_ID:/start.sh

--- a/build.sh
+++ b/build.sh
@@ -5,17 +5,17 @@ TAG_LATEST="$1"
 TAG_VERSION="$2"
 
 if [ -z "$DOCKER_IMAGE" ]; then
-	DOCKER_IMAGE="18.06-dind"
+	DOCKER_IMAGE="19.03.5-dind"
 	echo "Defaulting Docker image to $DOCKER_IMAGE"
 fi
 
 if [ -z "$MINIKUBE_VERSION" ]; then
-	MINIKUBE_VERSION="v0.30.0"
+	MINIKUBE_VERSION="v1.0.1"
 	echo "Defaulting Minikube version to $MINIKUBE_VERSION"
 fi
 
 if [ -z "$KUBERNETES_VERSION" ]; then
-	KUBERNETES_VERSION="v1.10.5"
+	KUBERNETES_VERSION="v1.15.1"
 	echo "Defaulting Kubernetes version to $KUBERNETES_VERSION"
 fi
 
@@ -39,7 +39,8 @@ trap finish EXIT
 set -e
 
 echo "Starting dind"
-CONTAINER_ID=$(docker run --network $NETWORK --privileged -d --rm docker:$DOCKER_IMAGE)
+CONTAINER_ID=$(docker run -e DOCKER_TLS_CERTDIR=/certs --network $NETWORK --privileged -d --rm docker:$DOCKER_IMAGE)
+echo $CONTAINER_ID
 docker cp resources/entrypoint.sh $CONTAINER_ID:/entrypoint.sh
 docker cp resources/setup.sh $CONTAINER_ID:/setup.sh
 docker cp resources/start.sh $CONTAINER_ID:/start.sh
@@ -50,6 +51,7 @@ docker cp before-cluster.sh $CONTAINER_ID:/before-cluster.sh
 docker cp after-cluster.sh $CONTAINER_ID:/after-cluster.sh
 
 echo "Starting setup"
+sleep 3
 docker exec $CONTAINER_ID /setup.sh $KUBERNETES_VERSION $MINIKUBE_VERSION $STATIC_IP
 echo "Commiting new container"
 docker commit \

--- a/build.sh
+++ b/build.sh
@@ -10,12 +10,12 @@ if [ -z "$DOCKER_IMAGE" ]; then
 fi
 
 if [ -z "$MINIKUBE_VERSION" ]; then
-	MINIKUBE_VERSION="v1.3.0"
+	MINIKUBE_VERSION="v1.0.1"
 	echo "Defaulting Minikube version to $MINIKUBE_VERSION"
 fi
 
 if [ -z "$KUBERNETES_VERSION" ]; then
-	KUBERNETES_VERSION="v1.15.1"
+	KUBERNETES_VERSION="v1.14.8"
 	echo "Defaulting Kubernetes version to $KUBERNETES_VERSION"
 fi
 
@@ -39,7 +39,7 @@ trap finish EXIT
 set -e
 
 echo "Starting dind"
-CONTAINER_ID=$(docker run --network $NETWORK --privileged -d --rm docker:$DOCKER_IMAGE dockerd)
+CONTAINER_ID=$(docker run --network $NETWORK --privileged -d --rm -e DOCKER_TLS_CERTDIR='' docker:$DOCKER_IMAGE dockerd)
 echo $CONTAINER_ID
 docker cp resources/entrypoint.sh $CONTAINER_ID:/entrypoint.sh
 docker cp resources/setup.sh $CONTAINER_ID:/setup.sh

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ if [ -z "$DOCKER_IMAGE" ]; then
 fi
 
 if [ -z "$MINIKUBE_VERSION" ]; then
-	MINIKUBE_VERSION="v1.0.1"
+	MINIKUBE_VERSION="v1.3.1"
 	echo "Defaulting Minikube version to $MINIKUBE_VERSION"
 fi
 

--- a/resources/setup.sh
+++ b/resources/setup.sh
@@ -140,7 +140,6 @@ tar -c -C /var/lib/docker ./ | lz4 -3 > /docker-cache.tar.lz4
 
 # cleanup
 rm -f /setup.sh
-rm -f /images.sh
 
 # cleanup extra binaries
 rm -f /usr/local/bin/minikube

--- a/resources/setup.sh
+++ b/resources/setup.sh
@@ -41,7 +41,7 @@ function replaceHost(){
 }
 
 # start minikube, will fail, but s'ok is just for downloading things
-minikube start --vm-driver=none --kubernetes-version $KUBERNETES_VERSION --bootstrapper kubeadm --apiserver-ips $STATIC_IP,127.0.0.1 --apiserver-name minikube --extra-config=apiserver.advertise-address=$STATIC_IP --extra-config=kubeadm.ignore-preflight-errors=FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,Service-Docker || true
+minikube start --vm-driver=none --kubernetes-version $KUBERNETES_VERSION --bootstrapper kubeadm --apiserver-ips $STATIC_IP,127.0.0.1 --apiserver-name minikube --extra-config=apiserver.advertise-address=$STATIC_IP --extra-config=kubeadm.ignore-preflight-errors=FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,Service-Docker --alsologtostderr -v=8  || true
 
 # fix minikube generated configs, this shouldn't be required if minikube behaved itself / had args for all the things
 replaceHost

--- a/resources/setup.sh
+++ b/resources/setup.sh
@@ -41,7 +41,7 @@ function replaceHost(){
 }
 
 # start minikube, will fail, but s'ok is just for downloading things
-minikube start --vm-driver=none --kubernetes-version $KUBERNETES_VERSION --bootstrapper kubeadm --apiserver-ips $STATIC_IP,127.0.0.1 --apiserver-name minikube --extra-config=apiserver.advertise-address=$STATIC_IP --extra-config=kubeadm.ignore-preflight-errors=FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,Service-Docker --alsologtostderr -v=8  || true
+minikube start --vm-driver=none --kubernetes-version $KUBERNETES_VERSION --bootstrapper kubeadm --apiserver-ips $STATIC_IP,127.0.0.1 --apiserver-name minikube --extra-config=apiserver.advertise-address=$STATIC_IP --extra-config=kubeadm.ignore-preflight-errors=FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,Service-Docker || true
 
 # fix minikube generated configs, this shouldn't be required if minikube behaved itself / had args for all the things
 replaceHost

--- a/resources/setup.sh
+++ b/resources/setup.sh
@@ -13,7 +13,7 @@ echo $STATIC_IP > /var/kube-config/static-ip
 docker info
 
 # add deps
-apk add --update sudo curl ca-certificates bash less findutils supervisor tzdata socat lz4
+apk add --update sudo curl ca-certificates bash less findutils supervisor tzdata socat lz4 lxc bridge
 
 # add a static / known ip to the existing default network interface so that we can configure kube component to use that IP, and can re-use that IP again at boot time.
 ORIG_IP=$(hostname -i)
@@ -40,9 +40,21 @@ function replaceHost(){
     find /var /etc /root -type f -not -path "/etc/hosts" -not -size +1M -exec grep -il "$ORIG_IP" {} \; | xargs sed -i "s|$ORIG_IP|$STATIC_IP|g" || true
 }
 
-# start minikube, will fail, but s'ok is just for downloading things
-minikube start --vm-driver=none --kubernetes-version $KUBERNETES_VERSION --bootstrapper kubeadm --apiserver-ips $STATIC_IP,127.0.0.1 --apiserver-name minikube --extra-config=apiserver.advertise-address=$STATIC_IP || true
 
+# lxc profile create mod_br_netfilter
+# lxc profile set mod_br_netfilter linux.kernel_modules br_netfilter
+# lxc profile show mod_br_netfilter
+
+# # create fake /proc/sys/net/bridge/bridge-nf-call-iptables so minikube / kubeadm doesn't crack it
+# mkdir -p /lib/modules/4.19.76-linuxkit/modules.dep
+# modprobe br_netfilter
+touch /.dockerenv
+mkdir -p /proc/sys/net/bridge/ && echo "1" > /proc/sys/net/bridge/bridge-nf-call-iptables
+
+# start minikube, will fail, but s'ok is just for downloading things
+# minikube start --vm-driver=none --kubernetes-version $KUBERNETES_VERSION --bootstrapper kubeadm --apiserver-ips $STATIC_IP,127.0.0.1 --apiserver-name minikube --extra-config=apiserver.advertise-address=$STATIC_IP || true
+minikube start --vm-driver=none --kubernetes-version $KUBERNETES_VERSION --bootstrapper kubeadm --apiserver-ips $STATIC_IP,127.0.0.1 --apiserver-name minikube --extra-config=apiserver.advertise-address=$STATIC_IP --extra-config=kubeadm.ignore-preflight-errors=FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,Service-Docker || true
+echo "GOT PAST MINIKUBE START!!!"
 # fix minikube generated configs, this shouldn't be required if minikube behaved itself / had args for all the things
 replaceHost
 
@@ -64,7 +76,13 @@ fi
 } &
 
 # run kubeadm to create cluster - ignore preflights as there will be failures because of swap, systemd, lots of things..
+echo "1!!!!!!"
+/usr/bin/kubeadm config migrate --old-config /var/lib/kubeadm.yaml --new-config /var/lib/kubeadm.yaml
+echo "2!!!!!!"
+cat /var/lib/kubeadm.yaml
+echo "3!!!!!!"
 /usr/bin/kubeadm init --config /var/lib/kubeadm.yaml --ignore-preflight-errors=all
+echo "4!!!!!!"
 
 # use kube-config that contains the certs, rather than referencing files
 cp /etc/kubernetes/admin.conf /root/.kube/config


### PR DESCRIPTION
I needed to run Docker 19.03.5 in order to take advantage of a few refinements to BuildKit, but found I wasn't able to update without a few changes to the build and setup scripts.

Main changes:

1. Needed to disable TLS, since it's now enabled by default
2. Had to ignore a couple of preflight error checks in `kubeadm`
3. Needed to migrate the `/var/lib/kubeadm.yaml` via `kubadm migrate` before running `kubeadm init`

I updated the Minikube version to the latest that I could get working.  I also updated the default K8s version arbitrarily to the one we run.

I also updated the README to reflect the changes, and removed references to the no-longer-used `images.sh`

Not sure if you want to merge this in or not, but I thought I'd share.

Thanks for the great lib.  Serves us well for our local dev stack where I work.