### PR TITLE
Changes for higher k8s versions

### DIFF
--- a/after-cluster.sh
+++ b/after-cluster.sh
@@ -4,3 +4,16 @@ docker pull nginx:1.13 # used by config-serve
 # Add images here for them to be available at runtime
 # for example:
 # docker pull quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0
+
+kubectl config set-context --current --namespace=kube-system
+git clone https://github.com/kubernetes-csi/external-snapshotter
+kubectl create -f external-snapshotter/config/crd
+sed -i -e 's/default/kube-system/g' external-snapshotter/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
+sed -i -e 's/default/kube-system/g' external-snapshotter/deploy/kubernetes/csi-snapshotter/rbac-external-provisioner.yaml
+sed -i -e 's/default/kube-system/g' external-snapshotter/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
+kubectl create -f external-snapshotter/deploy/kubernetes/csi-snapshotter
+# Needed because of this todo: https://github.com/kubernetes-csi/external-snapshotter/blob/master/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml#L13
+sed -i -e 's/default/kube-system/g' external-snapshotter/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+sed -i -e 's/default/kube-system/g' external-snapshotter/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+kubectl create -f external-snapshotter/deploy/kubernetes/snapshot-controller
+kubectl config set-context --current --namespace=default

--- a/after-cluster.sh
+++ b/after-cluster.sh
@@ -4,16 +4,3 @@ docker pull nginx:1.13 # used by config-serve
 # Add images here for them to be available at runtime
 # for example:
 # docker pull quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0
-
-kubectl config set-context --current --namespace=kube-system
-git clone https://github.com/kubernetes-csi/external-snapshotter
-kubectl create -f external-snapshotter/config/crd
-sed -i -e 's/default/kube-system/g' external-snapshotter/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
-sed -i -e 's/default/kube-system/g' external-snapshotter/deploy/kubernetes/csi-snapshotter/rbac-external-provisioner.yaml
-sed -i -e 's/default/kube-system/g' external-snapshotter/deploy/kubernetes/csi-snapshotter/setup-csi-snapshotter.yaml
-kubectl create -f external-snapshotter/deploy/kubernetes/csi-snapshotter
-# Needed because of this todo: https://github.com/kubernetes-csi/external-snapshotter/blob/master/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml#L13
-sed -i -e 's/default/kube-system/g' external-snapshotter/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
-sed -i -e 's/default/kube-system/g' external-snapshotter/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
-kubectl create -f external-snapshotter/deploy/kubernetes/snapshot-controller
-kubectl config set-context --current --namespace=default

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ trap finish EXIT
 set -e
 
 echo "Starting dind"
-CONTAINER_ID=$(docker run --network $NETWORK --privileged -d --rm -e DOCKER_TLS_CERTDIR='' docker:$DOCKER_IMAGE dockerd)
+CONTAINER_ID=$(docker run --network $NETWORK --privileged -d --rm -e DOCKER_TLS_CERTDIR='' --hostname=minikube docker:$DOCKER_IMAGE dockerd)
 docker cp resources/entrypoint.sh $CONTAINER_ID:/entrypoint.sh
 docker cp resources/setup.sh $CONTAINER_ID:/setup.sh
 docker cp resources/start.sh $CONTAINER_ID:/start.sh

--- a/resources/setup.sh
+++ b/resources/setup.sh
@@ -105,10 +105,6 @@ kubectl -n kube-system delete cm coredns
 kubectl -n kube-system create -f coredns-cm.yaml
 rm -f coredns-cm.yaml
 
-# expose kube config so external consumers can call in
-cp /root/.minikube/proxy-client-ca.crt /var/kube-config/client.crt
-cp /root/.minikube/proxy-client-ca.key /var/kube-config/client.key
-cp /root/.minikube/ca.crt /var/kube-config/ca.crt
 # tweak cluster naming in config so it is identifiable as kind to test clients
 sed -i "s|kubernetes\|kubernetes-admin@kubernetes|kind|g" /root/.kube/config
 cp /root/.kube/config /var/kube-config/config

--- a/resources/setup.sh
+++ b/resources/setup.sh
@@ -10,7 +10,7 @@ echo $STATIC_IP > /var/kube-config/static-ip
 docker info
 
 # add deps
-apk add --update sudo curl ca-certificates bash less findutils supervisor tzdata socat lz4 conntrack-tools git
+apk add --update sudo curl ca-certificates bash less findutils supervisor tzdata socat lz4 conntrack-tools
 
 # add a static / known ip to the existing default network interface so that we can configure kube component to use that IP, and can re-use that IP again at boot time.
 ORIG_IP=$(hostname -i)
@@ -68,7 +68,13 @@ fi
 
 # run kubeadm to create cluster - ignore preflights as there will be failures because of swap, systemd, lots of things..
 if [ ! -f /var/lib/kubeadm.yaml ]; then
-    cp /var/tmp/minikube/kubeadm.yaml.new /var/lib/kubeadm.yaml
+    if [ -f /var/tmp/minikube/kubeadm.yaml ]
+    then
+      cp /var/tmp/minikube/kubeadm.yaml /var/lib/kubeadm.yaml
+    elif [ -f /var/tmp/minikube/kubeadm.yaml.new ]
+    then
+      cp /var/tmp/minikube/kubeadm.yaml.new /var/lib/kubeadm.yaml
+    fi
 fi
 /usr/bin/kubeadm config migrate --old-config /var/lib/kubeadm.yaml --new-config /var/lib/kubeadm.yaml
 /usr/bin/kubeadm init --config /var/lib/kubeadm.yaml --ignore-preflight-errors=all


### PR DESCRIPTION
This is in response to https://github.com/bsycorp/kind/issues/33 - with these changes and Minikube 1.9.2 I got K8s 1.18.2. and CSI Storage working. However, I did not include any backward compatibility checks! So these changes would be breaking.

Best regards,
stiller-leser