### PR TITLE
Fix for startup status check in start.sh

### DIFF
--- a/resources/start.sh
+++ b/resources/start.sh
@@ -49,7 +49,7 @@ while true; do
     POD_STATES=$(kubectl get po -n kube-system -o jsonpath='{.items[*].status.containerStatuses[*].state}' | tr ' ' '\n' | cut -d'[' -f 2 | cut -d':' -f 1 | sort | uniq)
     POD_READINESS=$(kubectl get po -n kube-system -o jsonpath='{.items[*].status.containerStatuses[*].ready}' | tr ' ' '\n' | sort | uniq)
     POD_COUNT=$(kubectl get po -n kube-system --no-headers | wc -l)
-    if [ "$POD_READINESS" == "true" ] && [ "$POD_STATES" == "running" ] && [ "$POD_PHASES" == "Running" ] && [ $POD_COUNT -gt 7 ]; then
+    if [ "$POD_READINESS" == "true" ] && [ "$POD_STATES" == "running" ] && [ "$POD_PHASES" == "Running" ] && [ $POD_COUNT -ge 7 ]; then
         echo "startup successful"
         break
     fi


### PR DESCRIPTION
The startup status check in `start.sh` should also have been updated to match the condition change in `setup.sh` in [this merged PR](https://github.com/bsycorp/kind/pull/34/files#diff-e07ff0bfda14b38558b26ed088243341R131)