### PR TITLE
increase the timeout to allow kubelet to provision kube-system pods o…

### DIFF
--- a/resources/start.sh
+++ b/resources/start.sh
@@ -42,7 +42,7 @@ supervisorctl -c /etc/supervisord.conf start config-serve
 echo "Starting Kubernetes.."
 supervisorctl -c /etc/supervisord.conf start kubelet
 
-sleep 5
+sleep 15
 kubectl wait --for=condition=ready --timeout 3m pod --all --all-namespaces
 kubectl get po --all-namespaces
 


### PR DESCRIPTION
**Why?**
kubectl wait command file when the sleep time is very short as the time is not sufficient for kubelet to provision the pods

kubelet: started
Error on line 46
Startup timeout, didn't become healthy after 3 mins.. details:
2021-03-10 03:48:41,951 INFO exited: start (exit status 1; not expected)

**What?**
increase the sleep time to allow kubelet to provision pods so that `kubectl wait` works